### PR TITLE
feat: add close icon to show summary modal

### DIFF
--- a/src/components/templates/TemplateSearchPortal.vue
+++ b/src/components/templates/TemplateSearchPortal.vue
@@ -2,12 +2,16 @@
     <div class="search-portal-wrapper">
         <div class="summary" v-if="isSummary">
             <div class="so-btn">
-                <AtomButton @click.native="showSummary">
+                <AtomButton @click.native="showSummary" v-show="!summary.show">
                     {{ summary.btn }} Summary
                 </AtomButton>
             </div>
             <br />
             <div class="so-summary" v-show="summary.show">
+                <span class="close-button">
+                    <AtomIcon @click.native="showSummary" :icon="'close'" size="">
+                    </AtomIcon>
+                </span>
                 <p class="so-total">
                     Total Request : {{ summary.totalRequest }}
                 </p>
@@ -46,41 +50,17 @@
                 </div>
             </div>
         </div>
-        <b-table
-            :paginated="true"
-            :per-page="10"
-            :data="isEmpty ? [] : parkingRequests"
-            :bordered="true"
-            :hoverable="true"
-            :loading="isLoading"
-            :focusable="true"
-            :mobile-cards="hasMobileCards"
-            :narrowed="true"
-            :sticky-header="true"
-            height="800"
-        >
-            <b-table-column
-                field="ID"
-                label="ID"
-                width="40"
-                numeric
-                v-slot="props"
-                sortable
-                headerClass="id-column-parent"
-                cellClass="id-column-parent"
-            >
+        <b-table :paginated="true" :per-page="10" :data="isEmpty ? [] : parkingRequests" :bordered="true"
+            :hoverable="true" :loading="isLoading" :focusable="true" :mobile-cards="hasMobileCards" :narrowed="true"
+            :sticky-header="true" height="800">
+            <b-table-column field="ID" label="ID" width="40" numeric v-slot="props" sortable
+                headerClass="id-column-parent" cellClass="id-column-parent">
                 <div class="id-column">
                     {{ props.row.ID }}
                 </div>
             </b-table-column>
 
-            <b-table-column
-                field="UpdatedAt"
-                label="Date"
-                centered
-                v-slot="props"
-                sortable
-            >
+            <b-table-column field="UpdatedAt" label="Date" centered v-slot="props" sortable>
                 <div class="date-column">
                     <div>
                         <p class="tag">UpdatedAt:</p>
@@ -100,29 +80,17 @@
                 </div>
             </b-table-column>
 
-            <b-table-column
-                field="Priority"
-                label="Priority"
-                v-slot="props"
-                sortable
-            >
-                <span
-                    class="tag"
-                    :class="{
-                        'is-info': props.row.Priority === 1,
-                        'my-status': props.row.Priority === 2,
-                        'is-danger': props.row.Priority === 3,
-                    }"
-                >
+            <b-table-column field="Priority" label="Priority" v-slot="props" sortable>
+                <span class="tag" :class="{
+                    'is-info': props.row.Priority === 1,
+                    'my-status': props.row.Priority === 2,
+                    'is-danger': props.row.Priority === 3,
+                }">
                     <b> {{ getPriority(props.row.Priority) }}</b>
                 </span>
             </b-table-column>
 
-            <b-table-column
-                field="contact"
-                label="Contact Details"
-                v-slot="props"
-            >
+            <b-table-column field="contact" label="Contact Details" v-slot="props">
                 <div class="contact-column">
                     <div class="primary">
                         <p>
@@ -166,37 +134,15 @@
                 </div>
             </b-table-column>
 
-            <b-table-column
-                field="comments"
-                label="Comments"
-                v-slot="props"
-                width="10px"
-            >
-                <AtomTextarea
-                    :size="'is-small'"
-                    :value="props.row.Comments"
-                    class="comment-width"
-                    :maxlength="1000"
-                    :rowNo="8"
-                    @changed="onCommentUpdate(props.row, ...arguments)"
-                ></AtomTextarea>
+            <b-table-column field="comments" label="Comments" v-slot="props" width="10px">
+                <AtomTextarea :size="'is-small'" :value="props.row.Comments" class="comment-width" :maxlength="1000"
+                    :rowNo="8" @changed="onCommentUpdate(props.row, ...arguments)"></AtomTextarea>
             </b-table-column>
 
-            <b-table-column
-                field="Agent"
-                label="Agent"
-                width="100px"
-                sortable
-                searchable
-            >
+            <b-table-column field="Agent" label="Agent" width="100px" sortable searchable>
                 <template #searchable="props">
-                    <AtomSelectInput
-                        :size="'is-small'"
-                        :list="agentList"
-                        v-model="props.filters['Agent']"
-                        label=""
-                        placeholder="Agent"
-                    >
+                    <AtomSelectInput :size="'is-small'" :list="agentList" v-model="props.filters['Agent']" label=""
+                        placeholder="Agent">
                     </AtomSelectInput>
                 </template>
                 <template v-slot="props">
@@ -205,35 +151,19 @@
                             <span class="tag my-status">
                                 {{ props.row.Agent }}
                             </span>
-                            <AtomSelectInput
-                                :size="'is-small'"
-                                :list="agentList"
-                                @changed="
-                                    onAgentUpdate(props.row, ...arguments)
-                                "
-                                label=""
-                                placeholder="Select Agent"
-                            >
+                            <AtomSelectInput :size="'is-small'" :list="agentList" @changed="
+                                onAgentUpdate(props.row, ...arguments)
+                                " label="" placeholder="Select Agent">
                             </AtomSelectInput>
                         </div>
                     </div>
                 </template>
             </b-table-column>
 
-            <b-table-column
-                field="NextCall"
-                label="Status/Next Call"
-                width="90px"
-                sortable
-                searchable
-            >
+            <b-table-column field="NextCall" label="Status/Next Call" width="90px" sortable searchable>
                 <template #searchable="props">
-                    <AtomSelectInput
-                        :size="'is-small'"
-                        :list="statusList"
-                        class="column-width"
-                        v-model="props.filters['Status']"
-                    >
+                    <AtomSelectInput :size="'is-small'" :list="statusList" class="column-width"
+                        v-model="props.filters['Status']">
                     </AtomSelectInput>
                 </template>
                 <template v-slot="props">
@@ -242,25 +172,17 @@
                             <span class="tag my-status">
                                 {{ statusList[props.row.Status].name }}
                             </span>
-                            <AtomSelectInput
-                                :size="'is-small'"
-                                :list="statusList"
-                                class="column-width"
-                                @changed="
-                                    onStatusUpdate(props.row, ...arguments)
-                                "
-                            >
+                            <AtomSelectInput :size="'is-small'" :list="statusList" class="column-width" @changed="
+                                onStatusUpdate(props.row, ...arguments)
+                                ">
                             </AtomSelectInput>
                         </div>
                         <div class="next-call-part">
-                            <span
-                                class="tag my-status"
-                                :class="{
-                                    'is-danger': isCallDelayed(
-                                        props.row.NextCall,
-                                    ),
-                                }"
-                            >
+                            <span class="tag my-status" :class="{
+                                'is-danger': isCallDelayed(
+                                    props.row.NextCall,
+                                ),
+                            }">
                                 <b>
                                     {{
                                         new Date(
@@ -269,11 +191,8 @@
                                     }}
                                 </b>
                             </span>
-                            <AtomDatePicker
-                                :size="'is-small'"
-                                class="column-width"
-                                @changed="onDateUpdate(props.row, ...arguments)"
-                            >
+                            <AtomDatePicker :size="'is-small'" class="column-width"
+                                @changed="onDateUpdate(props.row, ...arguments)">
                             </AtomDatePicker>
                         </div>
                     </div>
@@ -283,12 +202,9 @@
             <b-table-column field="lat_lng" label="Lat/Lng" v-slot="props">
                 <div class="lat-lng-column">
                     <div class="lat-lng-link">
-                        <a
-                            target="_blank"
-                            @click="
-                                toSrp(props.row.Latitude, props.row.Longitude)
-                            "
-                        >
+                        <a target="_blank" @click="
+                            toSrp(props.row.Latitude, props.row.Longitude)
+                            ">
                             {{
                                 props.row.Latitude.toFixed(6) +
                                 ',' +
@@ -299,16 +215,11 @@
 
                     <div class="lat-lng-input">
                         <p>LatLng:</p>
-                        <AtomInput
-                            :size="'is-small'"
-                            :value="
-                                getLatLng(
-                                    props.row.Latitude.toFixed(6),
-                                    props.row.Longitude.toFixed(6),
-                                )
-                            "
-                            @changed="updateLatLng(props.row, ...arguments)"
-                        >
+                        <AtomInput :size="'is-small'" :value="getLatLng(
+                            props.row.Latitude.toFixed(6),
+                            props.row.Longitude.toFixed(6),
+                        )
+                            " @changed="updateLatLng(props.row, ...arguments)">
                         </AtomInput>
                     </div>
                 </div>
@@ -331,10 +242,12 @@ import AtomDatePicker from '../atoms/AtomDatePicker.vue';
 import AtomInput from '../atoms/AtomInput.vue';
 import AtomSelectInput from '../atoms/AtomSelectInput.vue';
 import AtomTextarea from '../atoms/AtomTextarea.vue';
+import AtomIcon from '../atoms/AtomIcon'
 
 export default {
     name: 'TemplateSearchPortal',
     components: {
+        AtomIcon,
         AtomTextarea,
         AtomSelectInput,
         AtomDatePicker,
@@ -551,8 +464,18 @@ $portal-font-size: 13px;
         padding: 1rem;
     }
 
+    .close-button {
+        background: none;
+        border: none;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        cursor: pointer;
+    }
+
     .column-width {
         width: 100px;
+
         @media only screen and (max-width: 1024px) {
             width: 150px;
         }
@@ -560,6 +483,7 @@ $portal-font-size: 13px;
 
     .comment-width {
         width: 330px;
+
         @media only screen and (max-width: 1024px) {
             width: 200px;
         }
@@ -569,6 +493,7 @@ $portal-font-size: 13px;
         .so-btn {
             text-align: right;
         }
+
         .so-summary {
             position: absolute;
             top: 120px;

--- a/src/components/templates/TemplateSearchPortal.vue
+++ b/src/components/templates/TemplateSearchPortal.vue
@@ -9,7 +9,11 @@
             <br />
             <div class="so-summary" v-show="summary.show">
                 <span class="close-button">
-                    <AtomIcon @click.native="showSummary" :icon="'close'" size="">
+                    <AtomIcon
+                        @click.native="showSummary"
+                        :icon="'close'"
+                        size=""
+                    >
                     </AtomIcon>
                 </span>
                 <p class="so-total">
@@ -50,17 +54,41 @@
                 </div>
             </div>
         </div>
-        <b-table :paginated="true" :per-page="10" :data="isEmpty ? [] : parkingRequests" :bordered="true"
-            :hoverable="true" :loading="isLoading" :focusable="true" :mobile-cards="hasMobileCards" :narrowed="true"
-            :sticky-header="true" height="800">
-            <b-table-column field="ID" label="ID" width="40" numeric v-slot="props" sortable
-                headerClass="id-column-parent" cellClass="id-column-parent">
+        <b-table
+            :paginated="true"
+            :per-page="10"
+            :data="isEmpty ? [] : parkingRequests"
+            :bordered="true"
+            :hoverable="true"
+            :loading="isLoading"
+            :focusable="true"
+            :mobile-cards="hasMobileCards"
+            :narrowed="true"
+            :sticky-header="true"
+            height="800"
+        >
+            <b-table-column
+                field="ID"
+                label="ID"
+                width="40"
+                numeric
+                v-slot="props"
+                sortable
+                headerClass="id-column-parent"
+                cellClass="id-column-parent"
+            >
                 <div class="id-column">
                     {{ props.row.ID }}
                 </div>
             </b-table-column>
 
-            <b-table-column field="UpdatedAt" label="Date" centered v-slot="props" sortable>
+            <b-table-column
+                field="UpdatedAt"
+                label="Date"
+                centered
+                v-slot="props"
+                sortable
+            >
                 <div class="date-column">
                     <div>
                         <p class="tag">UpdatedAt:</p>
@@ -80,17 +108,29 @@
                 </div>
             </b-table-column>
 
-            <b-table-column field="Priority" label="Priority" v-slot="props" sortable>
-                <span class="tag" :class="{
-                    'is-info': props.row.Priority === 1,
-                    'my-status': props.row.Priority === 2,
-                    'is-danger': props.row.Priority === 3,
-                }">
+            <b-table-column
+                field="Priority"
+                label="Priority"
+                v-slot="props"
+                sortable
+            >
+                <span
+                    class="tag"
+                    :class="{
+                        'is-info': props.row.Priority === 1,
+                        'my-status': props.row.Priority === 2,
+                        'is-danger': props.row.Priority === 3,
+                    }"
+                >
                     <b> {{ getPriority(props.row.Priority) }}</b>
                 </span>
             </b-table-column>
 
-            <b-table-column field="contact" label="Contact Details" v-slot="props">
+            <b-table-column
+                field="contact"
+                label="Contact Details"
+                v-slot="props"
+            >
                 <div class="contact-column">
                     <div class="primary">
                         <p>
@@ -134,15 +174,37 @@
                 </div>
             </b-table-column>
 
-            <b-table-column field="comments" label="Comments" v-slot="props" width="10px">
-                <AtomTextarea :size="'is-small'" :value="props.row.Comments" class="comment-width" :maxlength="1000"
-                    :rowNo="8" @changed="onCommentUpdate(props.row, ...arguments)"></AtomTextarea>
+            <b-table-column
+                field="comments"
+                label="Comments"
+                v-slot="props"
+                width="10px"
+            >
+                <AtomTextarea
+                    :size="'is-small'"
+                    :value="props.row.Comments"
+                    class="comment-width"
+                    :maxlength="1000"
+                    :rowNo="8"
+                    @changed="onCommentUpdate(props.row, ...arguments)"
+                ></AtomTextarea>
             </b-table-column>
 
-            <b-table-column field="Agent" label="Agent" width="100px" sortable searchable>
+            <b-table-column
+                field="Agent"
+                label="Agent"
+                width="100px"
+                sortable
+                searchable
+            >
                 <template #searchable="props">
-                    <AtomSelectInput :size="'is-small'" :list="agentList" v-model="props.filters['Agent']" label=""
-                        placeholder="Agent">
+                    <AtomSelectInput
+                        :size="'is-small'"
+                        :list="agentList"
+                        v-model="props.filters['Agent']"
+                        label=""
+                        placeholder="Agent"
+                    >
                     </AtomSelectInput>
                 </template>
                 <template v-slot="props">
@@ -151,19 +213,35 @@
                             <span class="tag my-status">
                                 {{ props.row.Agent }}
                             </span>
-                            <AtomSelectInput :size="'is-small'" :list="agentList" @changed="
-                                onAgentUpdate(props.row, ...arguments)
-                                " label="" placeholder="Select Agent">
+                            <AtomSelectInput
+                                :size="'is-small'"
+                                :list="agentList"
+                                @changed="
+                                    onAgentUpdate(props.row, ...arguments)
+                                "
+                                label=""
+                                placeholder="Select Agent"
+                            >
                             </AtomSelectInput>
                         </div>
                     </div>
                 </template>
             </b-table-column>
 
-            <b-table-column field="NextCall" label="Status/Next Call" width="90px" sortable searchable>
+            <b-table-column
+                field="NextCall"
+                label="Status/Next Call"
+                width="90px"
+                sortable
+                searchable
+            >
                 <template #searchable="props">
-                    <AtomSelectInput :size="'is-small'" :list="statusList" class="column-width"
-                        v-model="props.filters['Status']">
+                    <AtomSelectInput
+                        :size="'is-small'"
+                        :list="statusList"
+                        class="column-width"
+                        v-model="props.filters['Status']"
+                    >
                     </AtomSelectInput>
                 </template>
                 <template v-slot="props">
@@ -172,17 +250,25 @@
                             <span class="tag my-status">
                                 {{ statusList[props.row.Status].name }}
                             </span>
-                            <AtomSelectInput :size="'is-small'" :list="statusList" class="column-width" @changed="
-                                onStatusUpdate(props.row, ...arguments)
-                                ">
+                            <AtomSelectInput
+                                :size="'is-small'"
+                                :list="statusList"
+                                class="column-width"
+                                @changed="
+                                    onStatusUpdate(props.row, ...arguments)
+                                "
+                            >
                             </AtomSelectInput>
                         </div>
                         <div class="next-call-part">
-                            <span class="tag my-status" :class="{
-                                'is-danger': isCallDelayed(
-                                    props.row.NextCall,
-                                ),
-                            }">
+                            <span
+                                class="tag my-status"
+                                :class="{
+                                    'is-danger': isCallDelayed(
+                                        props.row.NextCall,
+                                    ),
+                                }"
+                            >
                                 <b>
                                     {{
                                         new Date(
@@ -191,8 +277,11 @@
                                     }}
                                 </b>
                             </span>
-                            <AtomDatePicker :size="'is-small'" class="column-width"
-                                @changed="onDateUpdate(props.row, ...arguments)">
+                            <AtomDatePicker
+                                :size="'is-small'"
+                                class="column-width"
+                                @changed="onDateUpdate(props.row, ...arguments)"
+                            >
                             </AtomDatePicker>
                         </div>
                     </div>
@@ -202,9 +291,12 @@
             <b-table-column field="lat_lng" label="Lat/Lng" v-slot="props">
                 <div class="lat-lng-column">
                     <div class="lat-lng-link">
-                        <a target="_blank" @click="
-                            toSrp(props.row.Latitude, props.row.Longitude)
-                            ">
+                        <a
+                            target="_blank"
+                            @click="
+                                toSrp(props.row.Latitude, props.row.Longitude)
+                            "
+                        >
                             {{
                                 props.row.Latitude.toFixed(6) +
                                 ',' +
@@ -215,11 +307,16 @@
 
                     <div class="lat-lng-input">
                         <p>LatLng:</p>
-                        <AtomInput :size="'is-small'" :value="getLatLng(
-                            props.row.Latitude.toFixed(6),
-                            props.row.Longitude.toFixed(6),
-                        )
-                            " @changed="updateLatLng(props.row, ...arguments)">
+                        <AtomInput
+                            :size="'is-small'"
+                            :value="
+                                getLatLng(
+                                    props.row.Latitude.toFixed(6),
+                                    props.row.Longitude.toFixed(6),
+                                )
+                            "
+                            @changed="updateLatLng(props.row, ...arguments)"
+                        >
                         </AtomInput>
                     </div>
                 </div>
@@ -242,7 +339,7 @@ import AtomDatePicker from '../atoms/AtomDatePicker.vue';
 import AtomInput from '../atoms/AtomInput.vue';
 import AtomSelectInput from '../atoms/AtomSelectInput.vue';
 import AtomTextarea from '../atoms/AtomTextarea.vue';
-import AtomIcon from '../atoms/AtomIcon'
+import AtomIcon from '../atoms/AtomIcon';
 
 export default {
     name: 'TemplateSearchPortal',


### PR DESCRIPTION
This PR adds a close (cross) icon to the show summary modal, allowing users to easily close the modal.
![cross-icon](https://github.com/user-attachments/assets/c97a4e93-cab3-4107-9e11-214f72ae133c)
