### PR TITLE
feat(analytics): add SSR-safe analytics layer (PR-1 of conversion-tracking)

### DIFF
--- a/src/lib/analytics/attribution.js
+++ b/src/lib/analytics/attribution.js
@@ -1,0 +1,149 @@
+// Attribution capture: reads campaign click-ids and UTM params from the
+// current URL on entry, persists them so they survive SPA navigation,
+// and exposes a merge API that every `track()` call uses.
+//
+// Storage strategy:
+//   - sessionStorage.parkspot_attrib  → JSON of { gclid, gbraid, wbraid,
+//     utm_source, utm_medium, utm_campaign, utm_content, utm_term }
+//   - cookie parkspot_gclid (90 days, SameSite=Lax, Secure)
+//     → mirrors `gclid` only. Google Ads attribution window is 90 days,
+//       which exceeds a typical session — we keep the click-id alive
+//       across browser restarts so a delayed conversion still attributes.
+//
+// All exports are SSR-safe: every function bails early when there is no
+// `window` / `document` / `sessionStorage` (vite-ssg prerender).
+
+const STORAGE_KEY = 'parkspot_attrib';
+const GCLID_COOKIE = 'parkspot_gclid';
+const GCLID_COOKIE_DAYS = 90;
+
+const ATTRIBUTION_KEYS = [
+    'gclid',
+    'gbraid',
+    'wbraid',
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_content',
+    'utm_term',
+];
+
+function isBrowser() {
+    return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function safeSessionStorage() {
+    if (!isBrowser()) return null;
+    try {
+        // Touch the API — Safari private mode throws on access.
+        return window.sessionStorage;
+    } catch {
+        return null;
+    }
+}
+
+function readGclidCookie() {
+    if (!isBrowser()) return null;
+    const cookies = document.cookie ? document.cookie.split(';') : [];
+    for (const raw of cookies) {
+        const [name, ...rest] = raw.trim().split('=');
+        if (name === GCLID_COOKIE) {
+            return decodeURIComponent(rest.join('='));
+        }
+    }
+    return null;
+}
+
+function writeGclidCookie(value) {
+    if (!isBrowser()) return;
+    const expires = new Date(
+        Date.now() + GCLID_COOKIE_DAYS * 24 * 60 * 60 * 1000,
+    ).toUTCString();
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie =
+        `${GCLID_COOKIE}=${encodeURIComponent(value)}; ` +
+        `expires=${expires}; path=/; SameSite=Lax${secure}`;
+}
+
+/**
+ * Read attribution params from `window.location.search` and persist
+ * any values that are present. Idempotent — safe to call on every
+ * route change, but in practice it is called once at app boot from
+ * `src/main.js`.
+ *
+ * @return {Record<string, string>|null} The captured params, or `null`
+ *   if SSR / no params present.
+ */
+export function captureFromUrl() {
+    if (!isBrowser()) return null;
+    const search = window.location.search;
+    if (!search) return getStored();
+
+    const params = new URLSearchParams(search);
+    const captured = {};
+    for (const key of ATTRIBUTION_KEYS) {
+        const value = params.get(key);
+        if (value) captured[key] = value;
+    }
+    if (Object.keys(captured).length === 0) return getStored();
+
+    // Merge with existing stored values so a subsequent landing that
+    // carries only `utm_*` (no gclid) doesn't blow away an earlier gclid.
+    const merged = { ...(readStored() || {}), ...captured };
+    writeStored(merged);
+    if (captured.gclid) writeGclidCookie(captured.gclid);
+    return getStored();
+}
+
+/**
+ * Read raw attribution from sessionStorage (without cookie merge).
+ * Mainly internal — most callers want `getStored()`.
+ *
+ * @return {Record<string, string>|null}
+ */
+export function readStored() {
+    const ss = safeSessionStorage();
+    if (!ss) return null;
+    try {
+        const raw = ss.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Write attribution to sessionStorage. Overwrites any existing value.
+ *
+ * @param {Record<string, string>} attribution
+ * @return {boolean} `true` if written, `false` if SSR / quota error.
+ */
+export function writeStored(attribution) {
+    const ss = safeSessionStorage();
+    if (!ss) return false;
+    try {
+        ss.setItem(STORAGE_KEY, JSON.stringify(attribution || {}));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Get the merged attribution view used by every `track()` call.
+ * Cookie-stored `gclid` wins over sessionStorage when both exist —
+ * the cookie is the longer-lived, authoritative source for Ads.
+ *
+ * @return {Record<string, string>} Empty object on SSR.
+ */
+export function getStored() {
+    if (!isBrowser()) return {};
+    const stored = readStored() || {};
+    const cookieGclid = readGclidCookie();
+    if (cookieGclid) {
+        return { ...stored, gclid: cookieGclid };
+    }
+    return stored;
+}

--- a/src/lib/analytics/consent.js
+++ b/src/lib/analytics/consent.js
@@ -1,0 +1,44 @@
+// Consent Mode v2 wrapper. Used by PR-2 (consent notice) but ships in
+// PR-1 so the public API is stable from day one.
+//
+// Per plan.md §1.7 / §2.8, parkspot's posture is disclosure-only: the
+// notice strip never changes consent flags. These helpers exist so the
+// posture is reversible — flipping all four flags to `denied` and
+// adding Accept buttons becomes a one-PR change.
+//
+// `gtag('consent', 'default', ...)` MUST run before any GTM/gtag.js
+// snippet. The intent is for `index.html` to call `setDefault()` inline
+// (or for the equivalent inline gtag block to be hand-written into
+// `index.html`), not for a Vue component to call it post-mount.
+
+import { gtag } from './dataLayer.js';
+
+/**
+ * Set the Consent Mode v2 default state. This MUST run before the GTM
+ * snippet so the very first page-view respects the chosen defaults.
+ *
+ * @param {{
+ *   ad_storage?: 'granted' | 'denied',
+ *   ad_user_data?: 'granted' | 'denied',
+ *   ad_personalization?: 'granted' | 'denied',
+ *   analytics_storage?: 'granted' | 'denied',
+ *   functionality_storage?: 'granted' | 'denied',
+ *   personalization_storage?: 'granted' | 'denied',
+ *   security_storage?: 'granted' | 'denied',
+ *   wait_for_update?: number,
+ *   region?: string[]
+ * }} consent
+ */
+export function setDefault(consent) {
+    gtag('consent', 'default', consent || {});
+}
+
+/**
+ * Update Consent Mode v2 state in response to a user choice (e.g. when
+ * a future Accept/Reject banner ships). No-op on the server.
+ *
+ * @param {Record<string, 'granted' | 'denied'>} consent
+ */
+export function update(consent) {
+    gtag('consent', 'update', consent || {});
+}

--- a/src/lib/analytics/dataLayer.js
+++ b/src/lib/analytics/dataLayer.js
@@ -1,0 +1,44 @@
+// SSR-safe wrapper around `window.dataLayer.push` and a `gtag()` shim.
+//
+// The whole analytics stack flows through these two helpers. Components
+// must not touch `window.dataLayer` directly — that breaks vite-ssg
+// prerender (no `window` during SSR) and bypasses the dev-mode PII
+// validator wired up in `index.js`.
+//
+// Both `push` and `gtag` are no-ops when `typeof window === 'undefined'`.
+
+/**
+ * Push an event payload onto `window.dataLayer`. No-op on the server.
+ *
+ * @param {Record<string, unknown>} payload
+ *   The full event object (including the `event` key). Callers are
+ *   expected to have already merged attribution / globals via
+ *   `index.js#track()` — this function does no enrichment of its own.
+ * @return {boolean} `true` if pushed, `false` if no-op'd (SSR).
+ */
+export function push(payload) {
+    if (typeof window === 'undefined') return false;
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push(payload);
+    return true;
+}
+
+/**
+ * Minimal `gtag()` shim. Mirrors the one Google's snippet installs
+ * (forwards `arguments` onto `dataLayer`) but is SSR-safe.
+ *
+ * Used by `consent.js` for Consent Mode v2 default/update calls. Kept
+ * here (not in consent.js) so any future caller that needs the shim —
+ * e.g. setting `gtag('config', ...)` — has one canonical entry point.
+ *
+ * @param {...unknown} args Variadic — passed through to `dataLayer`.
+ * @return {boolean} `true` if pushed, `false` if no-op'd (SSR).
+ */
+export function gtag(...args) {
+    if (typeof window === 'undefined') return false;
+    window.dataLayer = window.dataLayer || [];
+    // GTM's own shim uses the actual `arguments` object (not an array)
+    // so it's distinguishable from an event push. We mimic that shape.
+    window.dataLayer.push(args);
+    return true;
+}

--- a/src/lib/analytics/index.js
+++ b/src/lib/analytics/index.js
@@ -1,0 +1,115 @@
+// Public API of the analytics layer. Components import from this
+// module — never from `dataLayer.js` directly — so the SSR guards,
+// attribution merging, and dev-mode validation all run uniformly.
+//
+//   import { track, identify, setUserProperty, EVENTS, LEAD_TYPES } from '@/lib/analytics';
+//
+// The wrapper is deliberately small. Anything not directly tied to
+// "merge globals → validate → push" lives in a sibling module.
+
+import { push } from './dataLayer.js';
+import { getStored as getAttribution } from './attribution.js';
+import { EVENTS, LEAD_TYPES, validateEvent } from './schema.js';
+
+export { EVENTS, LEAD_TYPES };
+export { setDefault as setDefaultConsent, update as updateConsent } from './consent.js';
+
+function isBrowser() {
+    return typeof window !== 'undefined' && typeof document !== 'undefined';
+}
+
+function isDev() {
+    // `import.meta.env.DEV` is replaced statically by Vite during the
+    // build, so this branch is dead-code-eliminated in production.
+    try {
+        return Boolean(import.meta && import.meta.env && import.meta.env.DEV);
+    } catch {
+        return false;
+    }
+}
+
+function readPageDefaults() {
+    if (!isBrowser()) return {};
+    const defaults = {};
+    try {
+        defaults.page_path =
+            window.location.pathname + (window.location.search || '');
+    } catch {
+        // Some embedded contexts forbid `location` access. Skip silently.
+    }
+    try {
+        if (document.title) defaults.page_title = document.title;
+    } catch {
+        // Same as above.
+    }
+    return defaults;
+}
+
+/**
+ * Push a tracking event. SSR-safe (no-op when there is no `window`).
+ *
+ * Behaviour:
+ *   1. On the server, returns immediately.
+ *   2. Reads `page_path` / `page_title` from `window.location` /
+ *      `document.title` as defaults — overridable by `params`.
+ *   3. Merges attribution (gclid, gbraid, wbraid, utm_*) from storage.
+ *   4. In dev, validates against `schema.js` (throws on violation).
+ *   5. Pushes `{ event: eventName, ...mergedParams }` onto dataLayer.
+ *
+ * @param {string} eventName One of `EVENTS.*`.
+ * @param {Record<string, unknown>} [params] Per-event params. May
+ *   override page-default fields and attribution.
+ * @return {boolean} `true` if pushed, `false` if no-op'd.
+ */
+export function track(eventName, params = {}) {
+    if (!isBrowser()) return false;
+
+    const merged = {
+        ...readPageDefaults(),
+        ...getAttribution(),
+        ...params,
+    };
+
+    if (isDev()) {
+        // Validation is dev-only — production never throws because
+        // `isDev()` returns false and Vite tree-shakes the import path.
+        validateEvent(eventName, merged);
+    }
+
+    return push({ event: eventName, ...merged });
+}
+
+/**
+ * Set the user identity. Emits an `identify` event so GTM can forward
+ * `user_id` to GA4 and the user-properties bag to GA4 user dimensions.
+ *
+ * Note: pass internal user IDs only — never email/phone (Google
+ * rejects PII in `user_id`).
+ *
+ * @param {string} userId
+ * @param {Record<string, unknown>} [userProperties]
+ * @return {boolean} `true` if pushed, `false` if no-op'd.
+ */
+export function identify(userId, userProperties = {}) {
+    if (!isBrowser()) return false;
+    return track(EVENTS.IDENTIFY, {
+        user_id: userId,
+        user_properties: userProperties || {},
+    });
+}
+
+/**
+ * Set a single user property. Convenience over `identify()` when the
+ * user ID hasn't changed but a property has (e.g. `city` becomes
+ * known after geolocation resolves).
+ *
+ * @param {string} key
+ * @param {unknown} value
+ * @return {boolean} `true` if pushed, `false` if no-op'd.
+ */
+export function setUserProperty(key, value) {
+    if (!isBrowser()) return false;
+    return track(EVENTS.SET_USER_PROPERTY, {
+        user_properties: { [key]: value },
+    });
+}

--- a/src/lib/analytics/schema.js
+++ b/src/lib/analytics/schema.js
@@ -1,0 +1,213 @@
+// Event schema — single source of truth for event names, lead types,
+// and the dev-mode validator that catches schema drift before a bad
+// payload escapes to GTM.
+//
+// Mirrors `campaign-conversion-tracking/events.csv` and Appendix A of
+// `campaign-conversion-tracking/plan.md`. Update those docs whenever
+// this file changes.
+//
+// `validateEvent()` is intentionally a no-op outside dev so production
+// pays zero validation cost — the validator is a static-analysis tool
+// for engineers, not a runtime safety net.
+
+/**
+ * GA4 / parkspot event names. Use these constants instead of raw
+ * strings at every call site so renames are a single-file edit.
+ */
+export const EVENTS = Object.freeze({
+    PAGE_VIEW: 'page_view',
+    FUNNEL_VIEW: 'funnel_view',
+    FORM_START: 'form_start',
+    FORM_ERROR: 'form_error',
+    FORM_SUBMIT_ATTEMPT: 'form_submit_attempt',
+    IMAGE_UPLOAD_START: 'image_upload_start',
+    IMAGE_UPLOAD_COMPLETE: 'image_upload_complete',
+    GENERATE_LEAD: 'generate_lead',
+    LEAD_CONFIRMED: 'lead_confirmed',
+    SEARCH: 'search',
+    VIEW_SEARCH_RESULTS: 'view_search_results',
+    VIEW_ITEM_LIST: 'view_item_list',
+    SELECT_ITEM: 'select_item',
+    VIEW_ITEM: 'view_item',
+    BEGIN_CHECKOUT: 'begin_checkout',
+    PAYMENT_INITIATED: 'payment_initiated',
+    PURCHASE: 'purchase',
+    PURCHASE_CONFIRMED: 'purchase_confirmed',
+    // Identity / user-property updates. Not in the funnel taxonomy but
+    // still flow through `track()` (or `identify()`).
+    IDENTIFY: 'identify',
+    SET_USER_PROPERTY: 'set_user_property',
+});
+
+/**
+ * Lead-type values for the `lead_type` param on `generate_lead`.
+ * Locked by §1.4 of plan.md.
+ */
+export const LEAD_TYPES = Object.freeze({
+    PARKING_SEEKER: 'parking_seeker',
+    PARKING_OWNER: 'parking_owner',
+    CONTACT: 'contact',
+    TENTATIVE_BOOKING_AUTH: 'tentative_booking_auth',
+    TENTATIVE_BOOKING_GUEST: 'tentative_booking_guest',
+});
+
+// Required-param table per Appendix A. Keys are event names; values
+// are arrays of param names that MUST be present when the event is
+// pushed. Globals merged by the wrapper (page_path, gclid, utm_*,
+// client_id) are not validated here — those come from outside the
+// component's hands.
+const REQUIRED_PARAMS = Object.freeze({
+    [EVENTS.PAGE_VIEW]: ['page_path', 'page_title'],
+    [EVENTS.FUNNEL_VIEW]: ['funnel_name'],
+    [EVENTS.FORM_START]: ['funnel_name', 'step_index'],
+    [EVENTS.FORM_ERROR]: ['funnel_name', 'error_fields'],
+    [EVENTS.FORM_SUBMIT_ATTEMPT]: ['funnel_name'],
+    [EVENTS.IMAGE_UPLOAD_START]: ['funnel_name', 'image_count'],
+    [EVENTS.IMAGE_UPLOAD_COMPLETE]: [
+        'funnel_name',
+        'image_count',
+        'duration_ms',
+    ],
+    [EVENTS.GENERATE_LEAD]: [
+        'funnel_name',
+        'lead_type',
+        'value',
+        'currency',
+        'enhanced_conversion_data',
+    ],
+    [EVENTS.LEAD_CONFIRMED]: ['funnel_name'],
+    [EVENTS.SEARCH]: ['search_term'],
+    [EVENTS.VIEW_SEARCH_RESULTS]: ['funnel_name', 'item_count'],
+    [EVENTS.VIEW_ITEM_LIST]: ['funnel_name', 'items'],
+    [EVENTS.SELECT_ITEM]: ['funnel_name', 'items'],
+    [EVENTS.VIEW_ITEM]: ['funnel_name', 'items'],
+    [EVENTS.BEGIN_CHECKOUT]: ['funnel_name', 'value', 'currency', 'items'],
+    [EVENTS.PAYMENT_INITIATED]: [
+        'funnel_name',
+        'payment_provider',
+        'value',
+        'currency',
+        'transaction_id',
+    ],
+    [EVENTS.PURCHASE]: [
+        'funnel_name',
+        'transaction_id',
+        'value',
+        'currency',
+        'items',
+        'enhanced_conversion_data',
+    ],
+    [EVENTS.PURCHASE_CONFIRMED]: ['funnel_name', 'transaction_id'],
+    [EVENTS.IDENTIFY]: ['user_id'],
+    [EVENTS.SET_USER_PROPERTY]: [],
+});
+
+// PII keys that must NEVER appear at the top level of any event. They
+// are allowed only inside `enhanced_conversion_data` on `generate_lead`
+// and `purchase`. This is the dev-mode counterpart to GA4's own PII
+// scan — we'd rather throw locally than have Google reject the
+// property and yank our analytics access.
+const PII_KEYS = Object.freeze([
+    'email',
+    'email_address',
+    'phone',
+    'phone_number',
+]);
+
+const EVENTS_WITH_ENHANCED_CONVERSION_DATA = Object.freeze([
+    EVENTS.GENERATE_LEAD,
+    EVENTS.PURCHASE,
+]);
+
+function isKnownEvent(eventName) {
+    return Object.values(EVENTS).includes(eventName);
+}
+
+function hasOwn(obj, key) {
+    return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/**
+ * Throws a descriptive Error if the (eventName, params) pair violates
+ * the schema. Called from `index.js#track()` only when
+ * `import.meta.env.DEV === true` so production callers pay nothing.
+ *
+ * Validation rules:
+ *   - Event must be a known name (per `EVENTS`).
+ *   - All entries in `REQUIRED_PARAMS[eventName]` must be present and
+ *     not `undefined` / `null` / empty string. (`0` and `false` are OK.)
+ *   - Top-level keys must not include any PII. PII may appear inside
+ *     `enhanced_conversion_data`, and only on `generate_lead` /
+ *     `purchase`.
+ *
+ * @param {string} eventName
+ * @param {Record<string, unknown>} params
+ * @throws {Error} on any violation.
+ */
+export function validateEvent(eventName, params = {}) {
+    if (!isKnownEvent(eventName)) {
+        throw new Error(
+            `[analytics] Unknown event "${eventName}". ` +
+                `Add it to EVENTS in src/lib/analytics/schema.js or use a known event.`,
+        );
+    }
+
+    const required = REQUIRED_PARAMS[eventName] || [];
+    for (const key of required) {
+        const value = params[key];
+        const missing =
+            value === undefined ||
+            value === null ||
+            (typeof value === 'string' && value.length === 0);
+        if (missing) {
+            throw new Error(
+                `[analytics] Event "${eventName}" is missing required param "${key}". ` +
+                    `See schema.js / plan.md Appendix A.`,
+            );
+        }
+    }
+
+    // Top-level PII check.
+    for (const piiKey of PII_KEYS) {
+        if (hasOwn(params, piiKey)) {
+            throw new Error(
+                `[analytics] Event "${eventName}" carries PII at the top level ` +
+                    `("${piiKey}"). PII is allowed only inside ` +
+                    `enhanced_conversion_data on generate_lead/purchase. ` +
+                    `Did you forget to wrap it?`,
+            );
+        }
+    }
+
+    // `enhanced_conversion_data` is only valid on conversion events.
+    if (
+        hasOwn(params, 'enhanced_conversion_data') &&
+        !EVENTS_WITH_ENHANCED_CONVERSION_DATA.includes(eventName)
+    ) {
+        throw new Error(
+            `[analytics] enhanced_conversion_data is only allowed on ` +
+                `${EVENTS_WITH_ENHANCED_CONVERSION_DATA.join('/')} ` +
+                `events; saw it on "${eventName}".`,
+        );
+    }
+}
+
+/**
+ * Test-only export so unit tests can assert against the same required-
+ * param table the validator uses without re-importing the dictionary
+ * via a brittle internal path.
+ *
+ * @return {Record<string, ReadonlyArray<string>>}
+ */
+export function _getRequiredParams() {
+    return REQUIRED_PARAMS;
+}
+
+/**
+ * Test-only export — same rationale as `_getRequiredParams`.
+ *
+ * @return {ReadonlyArray<string>}
+ */
+export function _getPiiKeys() {
+    return PII_KEYS;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -24,10 +24,16 @@ import { routes, scrollBehavior } from './router';
 import { createAppStore, seedAppStore } from './store';
 import { metaInfoBridge } from './plugins/unhead-meta-adapter.js';
 import { cleanupEdgeInjectedStructuredData } from './plugins/edge-seo-handoff.js';
+import { captureFromUrl as captureAttribution } from './lib/analytics/attribution.js';
 
 configure({
     validateOnInput: true,
 });
+
+// Persist campaign click-ids and UTM params on first entry so every
+// subsequent SPA navigation / form submit can attribute correctly.
+// Runs once at module-eval time. SSR-safe (no-op on prerender).
+captureAttribution();
 
 // Route-enumeration hook for vite-ssg. Re-exported as a top-level named
 // export below — that's the only shape vite-ssg recognises. See

--- a/tests/lib/analytics/attribution.spec.js
+++ b/tests/lib/analytics/attribution.spec.js
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+    captureFromUrl,
+    getStored,
+    readStored,
+    writeStored,
+} from '@/lib/analytics/attribution.js';
+
+const STORAGE_KEY = 'parkspot_attrib';
+const GCLID_COOKIE = 'parkspot_gclid';
+
+function clearAllCookies() {
+    if (!document.cookie) return;
+    for (const raw of document.cookie.split(';')) {
+        const name = raw.trim().split('=')[0];
+        if (!name) continue;
+        document.cookie =
+            `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    }
+}
+
+function setLocation(search) {
+    // jsdom lets you reassign location.search.
+    window.history.replaceState({}, '', `/${search ? '?' + search : ''}`);
+}
+
+describe('analytics/attribution', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+        clearAllCookies();
+        setLocation('');
+    });
+
+    afterEach(() => {
+        sessionStorage.clear();
+        clearAllCookies();
+        setLocation('');
+    });
+
+    describe('captureFromUrl()', () => {
+        it('captures gclid + utm params and writes them to sessionStorage', () => {
+            setLocation(
+                'gclid=ABC123&utm_source=google&utm_medium=cpc&utm_campaign=jun',
+            );
+            const result = captureFromUrl();
+            expect(result).toMatchObject({
+                gclid: 'ABC123',
+                utm_source: 'google',
+                utm_medium: 'cpc',
+                utm_campaign: 'jun',
+            });
+            expect(JSON.parse(sessionStorage.getItem(STORAGE_KEY))).toMatchObject({
+                gclid: 'ABC123',
+                utm_source: 'google',
+            });
+        });
+
+        it('writes a parkspot_gclid cookie when gclid is present', () => {
+            setLocation('gclid=COOKIE_GCLID');
+            captureFromUrl();
+            expect(document.cookie).toContain(`${GCLID_COOKIE}=COOKIE_GCLID`);
+        });
+
+        it('does NOT write a gclid cookie when only utm_* are present', () => {
+            setLocation('utm_source=fb&utm_medium=cpc');
+            captureFromUrl();
+            expect(document.cookie).not.toContain(GCLID_COOKIE);
+        });
+
+        it('preserves prior values when a new landing carries only utm_*', () => {
+            // First landing — has gclid.
+            setLocation('gclid=KEEP_ME&utm_source=google');
+            captureFromUrl();
+            // Second landing — same session, only utm_* (different campaign).
+            setLocation('utm_source=fb');
+            captureFromUrl();
+            const merged = getStored();
+            expect(merged.gclid).toBe('KEEP_ME');
+            // utm_source overwrites — last touch wins for utm.
+            expect(merged.utm_source).toBe('fb');
+        });
+
+        it('returns existing stored attribution when URL has no params', () => {
+            writeStored({ gclid: 'OLD' });
+            const result = captureFromUrl();
+            expect(result).toMatchObject({ gclid: 'OLD' });
+        });
+
+        it('ignores unrelated query params', () => {
+            setLocation('gclid=Y&foo=bar&utm_source=g');
+            captureFromUrl();
+            const stored = readStored();
+            expect(stored).not.toHaveProperty('foo');
+            expect(stored.gclid).toBe('Y');
+        });
+    });
+
+    describe('getStored()', () => {
+        it('returns empty object when nothing is stored', () => {
+            expect(getStored()).toEqual({});
+        });
+
+        it('returns sessionStorage values', () => {
+            writeStored({ utm_source: 'google', utm_campaign: 'x' });
+            expect(getStored()).toEqual({
+                utm_source: 'google',
+                utm_campaign: 'x',
+            });
+        });
+
+        it('cookie gclid wins over sessionStorage gclid', () => {
+            writeStored({ gclid: 'SESSION_VALUE', utm_source: 's' });
+            // Set the cookie directly.
+            document.cookie = `${GCLID_COOKIE}=COOKIE_VALUE; path=/`;
+            const stored = getStored();
+            expect(stored.gclid).toBe('COOKIE_VALUE');
+            // Other params survive the merge.
+            expect(stored.utm_source).toBe('s');
+        });
+    });
+
+    describe('writeStored() / readStored()', () => {
+        it('round-trips an attribution object', () => {
+            writeStored({ utm_source: 'a', utm_medium: 'b' });
+            expect(readStored()).toEqual({ utm_source: 'a', utm_medium: 'b' });
+        });
+
+        it('readStored returns null when storage is empty', () => {
+            expect(readStored()).toBeNull();
+        });
+
+        it('readStored returns null for malformed JSON', () => {
+            sessionStorage.setItem(STORAGE_KEY, '{not json}');
+            expect(readStored()).toBeNull();
+        });
+    });
+});

--- a/tests/lib/analytics/consent.spec.js
+++ b/tests/lib/analytics/consent.spec.js
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setDefault, update } from '@/lib/analytics/consent.js';
+
+describe('analytics/consent', () => {
+    beforeEach(() => {
+        window.dataLayer = [];
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        window.dataLayer = [];
+    });
+
+    describe('setDefault()', () => {
+        it('pushes a gtag(consent, default, ...) tuple onto the dataLayer', () => {
+            setDefault({
+                ad_storage: 'granted',
+                ad_user_data: 'granted',
+                ad_personalization: 'granted',
+                analytics_storage: 'granted',
+            });
+            expect(window.dataLayer).toHaveLength(1);
+            const tuple = Array.from(window.dataLayer[0]);
+            expect(tuple[0]).toBe('consent');
+            expect(tuple[1]).toBe('default');
+            expect(tuple[2]).toMatchObject({
+                ad_storage: 'granted',
+                analytics_storage: 'granted',
+            });
+        });
+
+        it('handles a missing consent argument gracefully', () => {
+            setDefault();
+            expect(window.dataLayer).toHaveLength(1);
+            expect(Array.from(window.dataLayer[0])).toEqual([
+                'consent',
+                'default',
+                {},
+            ]);
+        });
+
+        it('no-ops on the server', () => {
+            vi.stubGlobal('window', undefined);
+            // Must not throw — simply returns false from the underlying gtag.
+            expect(() => setDefault({ ad_storage: 'granted' })).not.toThrow();
+        });
+    });
+
+    describe('update()', () => {
+        it('pushes a gtag(consent, update, ...) tuple onto the dataLayer', () => {
+            update({ analytics_storage: 'denied' });
+            const tuple = Array.from(window.dataLayer[0]);
+            expect(tuple).toEqual([
+                'consent',
+                'update',
+                { analytics_storage: 'denied' },
+            ]);
+        });
+    });
+});

--- a/tests/lib/analytics/dataLayer.spec.js
+++ b/tests/lib/analytics/dataLayer.spec.js
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { gtag, push } from '@/lib/analytics/dataLayer.js';
+
+describe('analytics/dataLayer', () => {
+    beforeEach(() => {
+        // Each test starts with a fresh dataLayer.
+        window.dataLayer = undefined;
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    describe('push()', () => {
+        it('initializes window.dataLayer if absent and pushes payload', () => {
+            const result = push({ event: 'page_view', page_path: '/x' });
+            expect(result).toBe(true);
+            expect(window.dataLayer).toEqual([
+                { event: 'page_view', page_path: '/x' },
+            ]);
+        });
+
+        it('appends to an existing dataLayer without overwriting prior entries', () => {
+            window.dataLayer = [{ event: 'first' }];
+            push({ event: 'second' });
+            expect(window.dataLayer).toEqual([
+                { event: 'first' },
+                { event: 'second' },
+            ]);
+        });
+
+        it('returns false and does nothing when window is undefined (SSR)', () => {
+            // Simulate SSR by stubbing `window` to undefined.
+            vi.stubGlobal('window', undefined);
+            const result = push({ event: 'page_view' });
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('gtag()', () => {
+        it('pushes the variadic arguments object onto the dataLayer', () => {
+            const result = gtag('consent', 'default', { ad_storage: 'granted' });
+            expect(result).toBe(true);
+            expect(window.dataLayer).toHaveLength(1);
+            // Per the GTM shim shape, args are pushed as an array-like.
+            expect(Array.from(window.dataLayer[0])).toEqual([
+                'consent',
+                'default',
+                { ad_storage: 'granted' },
+            ]);
+        });
+
+        it('no-ops on the server', () => {
+            vi.stubGlobal('window', undefined);
+            expect(gtag('consent', 'default', {})).toBe(false);
+        });
+    });
+});

--- a/tests/lib/analytics/index.spec.js
+++ b/tests/lib/analytics/index.spec.js
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    EVENTS,
+    LEAD_TYPES,
+    identify,
+    setUserProperty,
+    track,
+} from '@/lib/analytics/index.js';
+
+const STORAGE_KEY = 'parkspot_attrib';
+
+describe('analytics/index (public API)', () => {
+    beforeEach(() => {
+        window.dataLayer = [];
+        sessionStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        window.dataLayer = [];
+        sessionStorage.clear();
+    });
+
+    describe('track()', () => {
+        it('pushes a payload with the event name and merged page defaults', () => {
+            window.history.replaceState({}, '', '/some/path?x=1');
+            document.title = 'Test Title';
+            const ok = track(EVENTS.PAGE_VIEW, {
+                page_path: '/some/path?x=1',
+                page_title: 'Test Title',
+            });
+            expect(ok).toBe(true);
+            expect(window.dataLayer).toHaveLength(1);
+            expect(window.dataLayer[0]).toMatchObject({
+                event: 'page_view',
+                page_path: '/some/path?x=1',
+                page_title: 'Test Title',
+            });
+        });
+
+        it('merges attribution from sessionStorage into every push', () => {
+            sessionStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify({
+                    gclid: 'G123',
+                    utm_source: 'google',
+                    utm_campaign: 'jun',
+                }),
+            );
+            track(EVENTS.FUNNEL_VIEW, { funnel_name: 'vo_lead' });
+            const event = window.dataLayer[0];
+            expect(event.gclid).toBe('G123');
+            expect(event.utm_source).toBe('google');
+            expect(event.utm_campaign).toBe('jun');
+        });
+
+        it('lets explicit params override page defaults and attribution', () => {
+            sessionStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify({ utm_source: 'fb' }),
+            );
+            track(EVENTS.PAGE_VIEW, {
+                page_path: '/explicit',
+                page_title: 'Explicit',
+                utm_source: 'override',
+            });
+            const event = window.dataLayer[0];
+            expect(event.page_path).toBe('/explicit');
+            expect(event.utm_source).toBe('override');
+        });
+
+        it('throws (in dev) when a required param is missing', () => {
+            // Vitest exposes import.meta.env.DEV = true under `npm run test`.
+            expect(() =>
+                track(EVENTS.GENERATE_LEAD, {
+                    funnel_name: 'vo_lead',
+                    lead_type: LEAD_TYPES.PARKING_SEEKER,
+                    value: 500,
+                    currency: 'INR',
+                    // enhanced_conversion_data omitted
+                }),
+            ).toThrow(/missing required param/);
+        });
+
+        it('returns false and does nothing on the server', () => {
+            vi.stubGlobal('window', undefined);
+            const ok = track(EVENTS.PAGE_VIEW, {
+                page_path: '/x',
+                page_title: 'X',
+            });
+            expect(ok).toBe(false);
+        });
+    });
+
+    describe('identify()', () => {
+        it('emits an identify event with user_id and user_properties', () => {
+            identify('user_42', { is_authenticated: true, user_role: 'guest' });
+            expect(window.dataLayer).toHaveLength(1);
+            expect(window.dataLayer[0]).toMatchObject({
+                event: 'identify',
+                user_id: 'user_42',
+                user_properties: {
+                    is_authenticated: true,
+                    user_role: 'guest',
+                },
+            });
+        });
+
+        it('handles missing user_properties without crashing', () => {
+            identify('user_42');
+            expect(window.dataLayer[0]).toMatchObject({
+                event: 'identify',
+                user_id: 'user_42',
+                user_properties: {},
+            });
+        });
+    });
+
+    describe('setUserProperty()', () => {
+        it('emits a set_user_property event with the key/value pair', () => {
+            setUserProperty('city', 'Bangalore');
+            expect(window.dataLayer).toHaveLength(1);
+            expect(window.dataLayer[0]).toMatchObject({
+                event: 'set_user_property',
+                user_properties: { city: 'Bangalore' },
+            });
+        });
+    });
+});

--- a/tests/lib/analytics/schema.spec.js
+++ b/tests/lib/analytics/schema.spec.js
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+    EVENTS,
+    LEAD_TYPES,
+    validateEvent,
+    _getPiiKeys,
+} from '@/lib/analytics/schema.js';
+
+describe('analytics/schema', () => {
+    describe('EVENTS / LEAD_TYPES', () => {
+        it('exports the expected event-name set', () => {
+            // Spot-check the events that downstream PRs depend on.
+            expect(EVENTS.PAGE_VIEW).toBe('page_view');
+            expect(EVENTS.GENERATE_LEAD).toBe('generate_lead');
+            expect(EVENTS.PURCHASE).toBe('purchase');
+            expect(EVENTS.BEGIN_CHECKOUT).toBe('begin_checkout');
+            expect(EVENTS.PAYMENT_INITIATED).toBe('payment_initiated');
+        });
+
+        it('exports the five lead-type constants', () => {
+            expect(LEAD_TYPES).toEqual({
+                PARKING_SEEKER: 'parking_seeker',
+                PARKING_OWNER: 'parking_owner',
+                CONTACT: 'contact',
+                TENTATIVE_BOOKING_AUTH: 'tentative_booking_auth',
+                TENTATIVE_BOOKING_GUEST: 'tentative_booking_guest',
+            });
+        });
+
+        it('EVENTS object is frozen so callers cannot mutate the taxonomy', () => {
+            expect(Object.isFrozen(EVENTS)).toBe(true);
+            expect(Object.isFrozen(LEAD_TYPES)).toBe(true);
+        });
+    });
+
+    describe('validateEvent()', () => {
+        it('throws on an unknown event name', () => {
+            expect(() => validateEvent('not_a_real_event', {})).toThrow(
+                /Unknown event/,
+            );
+        });
+
+        it('throws when a required param is missing', () => {
+            expect(() =>
+                validateEvent(EVENTS.GENERATE_LEAD, {
+                    funnel_name: 'vo_lead',
+                    lead_type: LEAD_TYPES.PARKING_SEEKER,
+                    value: 500,
+                    currency: 'INR',
+                    // enhanced_conversion_data missing
+                }),
+            ).toThrow(/missing required param "enhanced_conversion_data"/);
+        });
+
+        it('treats null / undefined / empty string as missing', () => {
+            expect(() =>
+                validateEvent(EVENTS.FUNNEL_VIEW, { funnel_name: '' }),
+            ).toThrow(/missing required param "funnel_name"/);
+            expect(() =>
+                validateEvent(EVENTS.FUNNEL_VIEW, { funnel_name: null }),
+            ).toThrow(/missing required param "funnel_name"/);
+        });
+
+        it('accepts 0 and false as present (truthy-coercion bug guard)', () => {
+            expect(() =>
+                validateEvent(EVENTS.FORM_START, {
+                    funnel_name: 'vo_lead',
+                    step_index: 0,
+                }),
+            ).not.toThrow();
+        });
+
+        it('passes when all required params are present', () => {
+            expect(() =>
+                validateEvent(EVENTS.GENERATE_LEAD, {
+                    funnel_name: 'vo_lead',
+                    lead_type: LEAD_TYPES.PARKING_SEEKER,
+                    value: 500,
+                    currency: 'INR',
+                    enhanced_conversion_data: {
+                        email_address: 'x@y.z',
+                        phone_number: '+919999999999',
+                    },
+                }),
+            ).not.toThrow();
+        });
+
+        describe('PII guard', () => {
+            const piiKeys = _getPiiKeys();
+
+            for (const piiKey of piiKeys) {
+                it(`throws when "${piiKey}" appears at the top level of page_view`, () => {
+                    expect(() =>
+                        validateEvent(EVENTS.PAGE_VIEW, {
+                            page_path: '/x',
+                            page_title: 't',
+                            [piiKey]: 'leak@example.com',
+                        }),
+                    ).toThrow(/PII at the top level/);
+                });
+            }
+
+            it('allows PII inside enhanced_conversion_data on generate_lead', () => {
+                expect(() =>
+                    validateEvent(EVENTS.GENERATE_LEAD, {
+                        funnel_name: 'contact',
+                        lead_type: LEAD_TYPES.CONTACT,
+                        value: 100,
+                        currency: 'INR',
+                        enhanced_conversion_data: {
+                            email_address: 'visitor@example.com',
+                            phone_number: '+919999999999',
+                        },
+                    }),
+                ).not.toThrow();
+            });
+
+            it('allows PII inside enhanced_conversion_data on purchase', () => {
+                expect(() =>
+                    validateEvent(EVENTS.PURCHASE, {
+                        funnel_name: 'booking',
+                        transaction_id: 'tx_1',
+                        value: 1500,
+                        currency: 'INR',
+                        items: [{ item_id: 'spot-1' }],
+                        enhanced_conversion_data: {
+                            email_address: 'buyer@example.com',
+                            phone_number: '+919999999999',
+                        },
+                    }),
+                ).not.toThrow();
+            });
+
+            it('rejects enhanced_conversion_data on a non-conversion event', () => {
+                expect(() =>
+                    validateEvent(EVENTS.PAGE_VIEW, {
+                        page_path: '/x',
+                        page_title: 't',
+                        enhanced_conversion_data: {
+                            email_address: 'x@y.z',
+                        },
+                    }),
+                ).toThrow(/enhanced_conversion_data is only allowed/);
+            });
+        });
+    });
+});


### PR DESCRIPTION
…cking)

Adds src/lib/analytics/ with:
- track() / identify() / setUserProperty() public API
- SSR-safe dataLayer.push wrapper
- UTM and gclid capture in attribution.js
- Event schema constants and dev-mode PII validator
- Consent Mode v2 wrapper (used by PR-2)

Wires attribution.captureFromUrl() into src/main.js at boot.

Reference: campaign-conversion-tracking/plan.md §2.2